### PR TITLE
Implement missing options of bootstrap-datepicker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,5 +29,5 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[*.md]
+[*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,32 @@
+{
+  "predef": [
+    "document",
+    "window",
+    "-Promise"
+  ],
+  "browser": true,
+  "boss": true,
+  "curly": true,
+  "debug": false,
+  "devel": true,
+  "eqeqeq": true,
+  "evil": true,
+  "forin": false,
+  "immed": false,
+  "laxbreak": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": false,
+  "nonew": false,
+  "nomen": false,
+  "onevar": false,
+  "plusplus": false,
+  "regexp": false,
+  "undef": true,
+  "sub": true,
+  "strict": false,
+  "white": false,
+  "eqnull": true,
+  "esnext": true,
+  "unused": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ cache:
   directories:
     - node_modules
 
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
+
 install:
-  - npm install -g bower
-  - npm install
-  - bower install
+  - script/bootstrap
 
 script:
-  - npm test
+  - script/cibuild

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 /* global require, module */
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
@@ -16,5 +17,12 @@ var app = new EmberAddon();
 // modules that you would like to import into your application
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
+
+app.import('bower_components/bootstrap/dist/css/bootstrap.css');
+app.import('bower_components/bootstrap/dist/css/bootstrap.css.map', {
+  destDir: 'assets'
+});
+
+app.import('bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.de.js');
 
 module.exports = app.toTree();

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Alexander Sulim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Ember CLI datepicker
 
+[![Build Status](https://travis-ci.org/soulim/ember-cli-bootstrap-datepicker.svg?branch=master&style=flat)](https://travis-ci.org/soulim/ember-cli-bootstrap-datepicker)
+
 The addon provides you a `bootstrap-datepicker` input component. It can be used in Ember CLI applications.
 
-The input component is based on [bootstrap-datepicker library](https://github.com/eternicode/bootstrap-datepicker). The datepicker input field extends [`Ember.TextField`](http://emberjs.com/api/classes/Ember.TextField.html). That means you have all attribute bindings available on `Ember.TextField`.
+The input component is based on [bootstrap-datepicker library](https://github.com/eternicode/bootstrap-datepicker).
 
 ## Installation
+
+If you are using Ember CLI 0.1.5 and higher, just run within your project directory:
+
+```bash
+ember install:addon ember-cli-bootstrap-datepicker
+```
+
+When your Ember CLI version is below 0.1.5, please run within your project directory:
 
 ```bash
 npm install --save-dev ember-cli-bootstrap-datepicker
@@ -13,69 +23,166 @@ ember generate bootstrap-datepicker
 
 ## Usage
 
+Basic example:
+
 ```handlebars
 {{bootstrap-datepicker value=expiresAt}}
 ```
 
-The component supports many options of the bootstrap-datepicker library:
+The component supports many options of the bootstrap-datepicker library. Let me show you how to use them :sparkles:
 
-* **autoclose**, default value `true`
-* **format**, default value `dd.mm.yyyy`
-* **language**, default value `en`
-* **todayBtn**, default value `false`
-* **todayHighlight**, default value `false`
-* **weekStart**, default value 1 (Monday)
+### Available options
 
-Let me show you how to use all these options.
+#### autoclose
 
-Autoclose:
+Type: `Boolean`
+Default: `false`
 
 ```handlebars
-{{bootstrap-datepicker value=expiresAt autoclose=false}}
+{{bootstrap-datepicker value=expiresAt autoclose=true}}
 ```
 
-Format:
+#### calendarWeeks
+
+Type: `Boolean`
+Default: `false`
 
 ```handlebars
-{{bootstrap-datepicker value=expiresAt format="dd/mm/yy"}}
+{{bootstrap-datepicker value=expiresAt calendarWeeks=true}}
 ```
 
-language:
+#### clearBtn
 
-Default locale is `en`. When you need another language, you should import a locale file, e.g.
+Type: `Boolean`
+Default: `false`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt clearBtn=true}}
+```
+
+#### daysOfWeekDisabled
+
+Type: `Array` or `String`
+Default: `""` or `[]`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt daysOfWeekDisabled="1,2"}}
+```
+
+#### endDate
+
+Type: `Date` or `String`
+Default: `Infinity` (end of time)
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt endDate="01/01/2018"}}
+```
+
+#### forceParse
+
+Type: `Boolean`
+Default: `true`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt forceParse=false}}
+```
+
+#### format
+
+Type: `String`
+Default: `'mm/dd/yyyy'`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt format="dd.mm.yy"}}
+```
+
+#### keyboardNavigation
+
+Type: `Boolean`
+Default: `true`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt keyboardNavigation=false}}
+```
+
+#### language
+
+Type: `String`
+Default: `'en'`
+
+When you need another language, you should import a locale file using your Brocfile.js. Just import `bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.<LANGUAGE_CODE>.js`, e.g.:
 
 ```javascript
 // Brocfile.js
-
 app.import('bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.de.js');
 ```
-
 ```handlebars
+{{! somewhere in template }}
 {{bootstrap-datepicker value=expiresAt language="de"}}
 ```
 
-todayBtn:
+#### minViewMode
+
+Type: `Number` or `String`
+Default: `0` or `'days'`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt minViewMode="months"}}
+```
+
+#### orientation
+
+Type: `String`
+Default: `'auto'`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt orientation="right"}}
+```
+
+#### startDate
+
+Type: `Date` or `String`
+Default: `-Infinity` (beginning of time)
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt startDate="01/01/2014"}}
+```
+
+#### startView
+
+Type: `Number` or `String`
+Default: `0` or `'month'`
+
+```handlebars
+{{bootstrap-datepicker value=expiresAt startView="decade"}}
+```
+
+#### todayBtn
+
+Type: `Boolean`
+Default: `false`
 
 ```handlebars
 {{bootstrap-datepicker value=expiresAt todayBtn=true}}
 ```
 
-todayHighlight:
+#### todayHighlight
+
+Type: `Boolean`
+Default: `false`
 
 ```handlebars
 {{bootstrap-datepicker value=expiresAt todayHighlight=true}}
 ```
 
-weekStart:
+#### weekStart
+
+Type: `Number`
+Default: `0` (Sunday)
+
 
 ```handlebars
-{{bootstrap-datepicker value=expiresAt weekStart=0}}
-```
-
-All options at once:
-
-```handlebars
-{{bootstrap-datepicker value=expiresAt autoclose=false format="dd/mm/yy" language="de" todayBtn=true todayHighlight=true weekStart=0}}
+{{bootstrap-datepicker value=expiresAt weekStart=1}}
 ```
 
 ## Contributing
@@ -85,3 +192,7 @@ All options at once:
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+## License
+
+[MIT License](https://github.com/soulim/ember-cli-bootstrap-datepicker/blob/master/LICENSE.md)

--- a/addon/components/bootstrap-datepicker.js
+++ b/addon/components/bootstrap-datepicker.js
@@ -1,6 +1,46 @@
 import Ember from 'ember';
 
-export default Ember.TextField.extend({
+export default Ember.Component.extend({
+  instrumentDisplay: '{{input type="text"}}',
+
+  classNames: ['ember-text-field'],
+
+  tagName: 'input',
+
+  attributeBindings: [
+    'accesskey',
+    'autocomplete',
+    'autofocus',
+    'contenteditable',
+    'contextmenu',
+    'dir',
+    'disabled',
+    'draggable',
+    'dropzone',
+    'form',
+    'hidden',
+    'id',
+    'lang',
+    'list',
+    'max',
+    'min',
+    'name',
+    'placeholder',
+    'readonly',
+    'required',
+    'spellcheck',
+    'step',
+    'style',
+    'tabindex',
+    'title',
+    'translate',
+    'type'
+  ],
+
+  type: 'text',
+
+  value: null,
+
   setupBootstrapDatepicker: function() {
     var self = this,
         element = this.$(),
@@ -8,12 +48,22 @@ export default Ember.TextField.extend({
 
     element.
       datepicker({
-        autoclose: this.get('autoclose') || true,
-        format: this.get('format') || 'dd.mm.yyyy',
-        weekStart: this.get('weekStart') || 1,
-        todayHighlight: this.get('todayHighlight') || false,
-        todayBtn: this.get('todayBtn') || false,
-        language: this.get('language') || 'en'
+        autoclose: this.get('autoclose'),
+        calendarWeeks: this.get('calendarWeeks'),
+        clearBtn: this.get('clearBtn'),
+        daysOfWeekDisabled: this.get('daysOfWeekDisabled'),
+        endDate: this.get('endDate'),
+        forceParse: this.get('forceParse'),
+        format: this.get('format'),
+        keyboardNavigation: this.get('keyboardNavigation'),
+        language: this.get('language'),
+        minViewMode: this.get('minViewMode'),
+        orientation: this.get('orientation'),
+        startDate: this.get('startDate'),
+        startView: this.get('startView'),
+        todayBtn: this.get('todayBtn'),
+        todayHighlight: this.get('todayHighlight'),
+        weekStart: this.get('weekStart')
       }).
       on('changeDate', function(event) {
         Ember.run(function() {
@@ -22,15 +72,15 @@ export default Ember.TextField.extend({
       });
 
     if (value) {
-      element.datepicker('setDate', new Date(value));
-    };
+      element.datepicker('update', new Date(value));
+    }
   }.on('didInsertElement'),
 
   teardownBootstrapDatepicker: function() {
-    // no-op
+    this.$().datepicker('remove');
   }.on('willDestroyElement'),
 
-  didSelectDate: function(event) {
+  didSelectDate: function() {
     var date = this.$().datepicker('getUTCDate');
     this.set('value', date.toISOString());
   }

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.7.0",
-    "ember-data": "1.0.0-beta.10",
-    "ember-resolver": "~0.1.7",
+    "ember": "1.8.1",
+    "ember-data": "1.0.0-beta.12",
+    "ember-resolver": "~0.1.11",
     "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
@@ -15,6 +15,6 @@
     "qunit": "~1.15.0"
   },
   "devDependencies": {
-    "bootstrap-datepicker": "~1.3.0"
+    "bootstrap-datepicker": "~1.3.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 'use strict';
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-cli-bootstrap-datepicker",
   "version": "0.2.0",
+  "description": "Datepicker component for Ember CLI based on bootstrap-datepicker",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -17,16 +18,17 @@
   "author": "Alex Sulim",
   "license": "MIT",
   "devDependencies": {
-    "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.3.1",
+    "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "ember-cli": "0.1.2",
+    "ember-cli": "0.1.5",
     "ember-cli-content-security-policy": "0.3.0",
-    "ember-export-application-global": "^1.0.0",
+    "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-esnext": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.0",
-    "ember-data": "1.0.0-beta.10",
+    "ember-cli-qunit": "0.1.2",
+    "ember-data": "1.0.0-beta.12",
+    "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },
@@ -37,6 +39,7 @@
     "datepicker"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "defaultBlueprint": "bootstrap-datepicker"
   }
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Install all dependencies
+#
+# Usage: script/bootstrap
+
+set -o errexit
+
+npm install -g bower
+npm install
+bower install

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# Run tests on the continuous integration server
+#
+# Usage: script/cibuild
+
+set -o errexit
+
+ember test

--- a/script/publish-gh-pages
+++ b/script/publish-gh-pages
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+# Publish GitHub Pages
+#
+# Usage: script/publish-gh-pages
+
+set -o errexit
+
+echo 'Enter GitHub Pages commit message:'
+read message
+
+branch=$(git symbolic-ref --short -q HEAD)
+
+ember build --environment=production
+
+if git branch --list | grep --no-messages --quiet 'gh-pages'
+then
+  git checkout gh-pages
+else
+  git checkout --orphan gh-pages
+  git rm -rf .
+fi
+
+if [ ! -f .gitignore ]
+then
+  echo '/bower_components' > .gitignore
+  echo '/node_modules' >> .gitignore
+fi
+
+rm -rf assets crossdomain.xml index.html robots.txt tmp
+mv dist/* .
+rm -rf dist
+
+git add .
+git commit --all --message="$message"
+git push origin gh-pages
+
+git checkout "$branch"

--- a/script/server
+++ b/script/server
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# Run application server
+#
+# Usage: script/server
+
+set -o errexit
+
+ember server

--- a/script/test
+++ b/script/test
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# Run the local test suite
+#
+# Usage: script/test
+
+set -o errexit
+
+ember test --server

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>Ember CLI datepicker component</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -11,11 +11,15 @@
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/dummy.css">
+
+    {{content-for 'head-footer'}}
   </head>
   <body>
     {{content-for 'body'}}
 
     <script src="assets/vendor.js"></script>
     <script src="assets/dummy.js"></script>
+
+    {{content-for 'body-footer'}}
   </body>
 </html>

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,3 +1,84 @@
-html, body {
-  margin: 20px;
+/*
+  Narrow jumbotron
+  Source: http://getbootstrap.com/examples/jumbotron-narrow/
+*/
+
+/* Space out content a bit */
+body {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+.panel-footer pre {
+  padding: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  word-break: normal;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0
+}
+
+/* Everything but the jumbotron gets side spacing for mobile first views */
+.header,
+.footer {
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+/* Custom page header */
+.header {
+  border-bottom: 1px solid #e5e5e5;
+}
+/* Make the masthead heading the same height as the navigation */
+.header h3 {
+  padding-bottom: 19px;
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 40px;
+}
+
+/* Custom page footer */
+.footer {
+  padding-top: 19px;
+  color: #777;
+  border-top: 1px solid #e5e5e5;
+}
+
+/* Customize container */
+@media (min-width: 768px) {
+  .container {
+    max-width: 730px;
+  }
+}
+.container-narrow > hr {
+  margin: 30px 0;
+}
+
+/* Main marketing message and sign up button */
+.jumbotron {
+  text-align: center;
+  border-bottom: 1px solid #e5e5e5;
+}
+.jumbotron .btn {
+  padding: 14px 24px;
+  font-size: 21px;
+}
+
+/* Responsive: Portrait tablets and up */
+@media screen and (min-width: 768px) {
+  /* Remove the padding we set earlier */
+  .header,
+  .footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+  /* Space out the masthead */
+  .header {
+    margin-bottom: 30px;
+  }
+  /* Remove the bottom border on the jumbotron for visual effect */
+  .jumbotron {
+    border-bottom: 0;
+  }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,1 @@
-<h2 id='title'>Welcome to Ember.js</h2>
-
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,353 @@
+<div class="container">
+  <div class="header">
+    <nav>
+      <ul class="nav nav-pills pull-right">
+        <li role="presentation"><a href="https://travis-ci.org/soulim/ember-cli-bootstrap-datepicker"><img src="https://travis-ci.org/soulim/ember-cli-bootstrap-datepicker.svg?branch=master&style=flat"></a></li>
+      </ul>
+    </nav>
+    <h3 class="text-muted">Ember CLI datepicker component</h3>
+  </div>
+
+  <div class="jumbotron">
+    <p class="lead">This is a playground page of the date input component which might be used in any Ember CLI app. The component has just one dependency - <strong>brilliant</strong> <a href="https://github.com/eternicode/bootstrap-datepicker">bootstrap-datepicker library</a>.</p>
+    <p><a class="btn btn-lg btn-success" href="https://github.com/soulim/ember-cli-bootstrap-datepicker" role="button">Source Code</a></p>
+  </div>
+
+  <h2>Installation</h2>
+  <hr>
+
+  <p>If you are using Ember CLI 0.1.5 and higher, just run within your project directory:</p>
+
+
+  <pre>ember install:addon ember-cli-bootstrap-datepicker</pre>
+
+  <p>When your Ember CLI version is below 0.1.5, please run within your project directory:</p>
+
+  <pre>npm install --save-dev ember-cli-bootstrap-datepicker
+ember generate bootstrap-datepicker</pre>
+
+  <h2>Basic example</h2>
+  <hr>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>It's just a basic example. The component supports many options which you could use to customize the datepicker. Please, find all of them below.</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h2>All available options</h2>
+  <hr>
+
+  <h3>autoclose</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker autoclose=true
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>false</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker autoclose=true class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>calendarWeeks</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker calendarWeeks=true
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>false</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker calendarWeeks=true class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>clearBtn</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker clearBtn=true
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>false</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker clearBtn=true class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>daysOfWeekDisabled</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker daysOfWeekDisabled="1,2"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Array</code> or <code>String</code><br>
+        Default: <code>''</code> or <code>[]</code>
+      </p>
+      <p>Possible values are 0 (Sunday) to 6 (Saturday).</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker daysOfWeekDisabled="1,2" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>endDate</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker endDate="01/01/2018"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Date</code> or date as a <code>String</code><br>
+        Default: <code>Infinity</code> (end of time)
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker endDate="01/01/2018" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>forceParse</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker forceParse=false
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>true</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker forceParse=false class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>format</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker format="dd MM, yyyy"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>String</code><br>
+        Default: <code>'mm/dd/yyyy'</code>
+      </p>
+      <p>You could read more about a format string <a href="http://bootstrap-datepicker.readthedocs.org/en/release/options.html#format">here</a>.</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker format="dd MM, yyyy" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>keyboardNavigation</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker keyboardNavigation=false
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>true</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker keyboardNavigation=false class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>language</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker language="de"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>String</code><br>
+        Default: <code>'en'</code>
+      </p>
+      <p>Please note, to make German language available I've added one line into <code>Brocfile.js</code>:</p>
+      <pre><code>app.import('bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.de.js');</code></pre>
+
+      <p>Months are translated in German, date format is changed, and weeks start from Monday now. So it's pretty convenient :)</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker language="de" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>minViewMode</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker minViewMode="months"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Number</code> or <code>String</code><br>
+        Default: <code>0</code> or <code>"days"</code>
+      </p>
+      <p>Please, read more about possible values <a href="http://bootstrap-datepicker.readthedocs.org/en/release/options.html#minviewmode">here</a>.</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker minViewMode="months" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>orientation</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker orientation="right"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>String</code><br>
+        Default: <code>'auto'</code>
+      </p>
+      <blockquote>
+        <p>"orientation" refers to the location of the picker popup’s "anchor"; you can also think of it as the location of the trigger element (input, component, etc) relative to the picker.</p>
+        <footer>description of "orientation" option in <a href="http://bootstrap-datepicker.readthedocs.org/en/release/options.html#orientation">the documentation for bootstrap-datepicker</a></footer>
+      </blockquote>
+
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker orientation="right" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>startDate</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker startDate="01/01/2014"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Date</code> or date as a <code>String</code><br>
+        Default: <code>-Infinity</code> (beginning of time)
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker startDate="01/01/2014" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>startView</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker startView="decade"
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Number</code> or <code>String</code><br>
+        Default: <code>0</code> or <code>"month"</code>
+      </p>
+      <p>Please, read more about possible values <a href="http://bootstrap-datepicker.readthedocs.org/en/release/options.html#startview">here</a>.</p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker startView="decade" class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>todayBtn</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker todayBtn=true
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>false</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker todayBtn=true class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>todayHighlight</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker todayHighlight=true
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Boolean</code><br>
+        Default: <code>false</code>
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker todayHighlight=true class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <h3>weekStart</h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {{bootstrap-datepicker weekStart=1
+                             placeholder="Click to play"
+                             class="form-control"}}
+    </div>
+    <div class="panel-body">
+      <p>
+        Type: <code>Number</code><br>
+        Default: <code>0</code> (Sunday)
+      </p>
+    </div>
+    <div class="panel-footer">
+      <pre><code>&#123;&#123;bootstrap-datepicker weekStart=1 class="form-control"&#125;&#125;</code></pre>
+    </div>
+  </div>
+
+  <footer class="footer">
+    <p class="pull-right">Hosted on <a href="https://pages.github.com/">GitHub Pages</a></p>
+    <p>This project is maintained by <a href="http://sul.im/">Alex Sulim</a></p>
+  </footer>
+</div>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,16 +21,16 @@ module.exports = function(environment) {
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
-    ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    ENV.APP.LOG_VIEW_LOOKUPS = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';
-    ENV.locationType = 'auto';
+    ENV.locationType = 'none';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
@@ -40,7 +40,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    ENV.baseURL = '/ember-cli-bootstrap-datepicker/';
   }
 
   return ENV;

--- a/tests/dummy/public/robots.txt
+++ b/tests/dummy/public/robots.txt
@@ -1,3 +1,2 @@
-# robotstxt.org/
-
+# http://www.robotstxt.org
 User-agent: *

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -4,22 +4,16 @@ import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var App;
+  var application;
 
   var attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Router.reopen({
-    location: 'none'
-  });
-
   Ember.run(function() {
-    App = Application.create(attributes);
-    App.setupForTesting();
-    App.injectTestHelpers();
+    application = Application.create(attributes);
+    application.setupForTesting();
+    application.injectTestHelpers();
   });
 
-  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
-
-  return App;
+  return application;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -29,10 +29,11 @@
         zoom: 50%;
       }
     </style>
+
+    {{content-for 'head-footer'}}
+    {{content-for 'test-head-footer'}}
   </head>
   <body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
@@ -41,5 +42,8 @@
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
+
+    {{content-for 'body-footer'}}
+    {{content-for 'test-body-footer'}}
   </body>
 </html>

--- a/tests/integration/bootstrap-datepicker-test.js
+++ b/tests/integration/bootstrap-datepicker-test.js
@@ -1,0 +1,18 @@
+import { test, moduleForComponent } from 'ember-qunit';
+import startApp from '../helpers/start-app';
+import Ember from 'ember';
+
+var App;
+
+moduleForComponent('bootstrap-datepicker', 'bootstrap-datepicker component', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('...', function() {
+  expect(0);
+});

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -1,0 +1,42 @@
+import { test, moduleForComponent } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForComponent('bootstrap-datepicker', 'bootstrap-datepicker component');
+
+test('should be an input tag', function() {
+  expect(1);
+
+  equal('INPUT', this.$().prop('tagName'));
+});
+
+test('should display empty input field when no date is set', function(){
+  expect(1);
+
+  var component = this.subject({
+    value: null
+  });
+
+  equal(this.$().val(), '');
+});
+
+
+test('should display date with default format when no format is set', function(){
+  expect(1);
+
+  var component = this.subject({
+    value: '2014-12-31T00:00:00.000Z'
+  });
+
+  equal(this.$().val(), '12/31/2014');
+});
+
+test('should display date with custom format when format is set', function(){
+  expect(1);
+
+  var component = this.subject({
+    value: '2014-12-31T00:00:00.000Z',
+    format: 'dd.M.yy'
+  });
+
+  equal(this.$().val(), '31.Dec.14');
+});


### PR DESCRIPTION
- [x] Add more tests
- [x] [`calendarWeeks`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#calendarweeks)
- [x] [`clearBtn`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#clearbtn)
- [x] [`daysOfWeekDisabled`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#daysofweekdisabled)
- [x] [`endDate`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#enddate)
- [x] [`forceParse`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#forceparse)
- [x] [`keyboardNavigation`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#keyboardnavigation)
- [x] [`minViewMode`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#minviewmode)
- [x] [`orientation`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#orientation)
- [x] [`startDate`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#startdate)
- [x] [`startView`](http://bootstrap-datepicker.readthedocs.org/en/release/options.html#startview)
