### PR TITLE
Adding forceDateValue property

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -60,20 +60,21 @@ export default Ember.Mixin.create({
   }.on('willDestroyElement'),
 
   didChangeDate: function(event) {
-    var isoDate = null;
+	var newDate = null;
 
     if (event.date) {
       if (this.get('multidate')) {
-         // set value to array if multidate
-         isoDate = this.$().datepicker('getUTCDates').map(function(date) {
-           return date.toISOString();
-         });
-      }
-      else {
-         isoDate = this.$().datepicker('getUTCDate').toISOString();
-      }
+			// set value to array if multidate
+			newDate = this.$().datepicker('getUTCDates').map(function(date) {
+				return date.toISOString();
+			});
+		} else if (event.date && this.get('forceDateValue')) {
+			newDate = event.date;
+		} else if (event.date && !this.get('forceDateValue')) {
+			newDate = this.$().datepicker('getUTCDate').toISOString();
+		}
     }
 
-    this.set('value', isoDate);
+    this.set('value', newDate);
   }
 });

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -65,3 +65,20 @@ test('should set dates provided by value (multidate, multidateSeparator provided
   equal(this.$().val(), '01/13/2015;01/07/2015;01/15/2015', 'should set value as input field value using multidate separator');
   equal(this.$().datepicker('getDates').length, 3, 'should set internal datepicker dates by value');
 });
+
+test('should use forceDateValue to set value as JS Date objects instead of ISOString', function(){
+  expect(1);
+
+  var date = new Date();
+  var newDate = new Date("2015-02-10");
+
+  var component = this.subject({
+    value: date,
+    multidate: false,
+	forceDateValue: true
+  });
+
+  component.set('value', newDate);
+
+  equal(component.get('value'), newDate, "Value should be the date object set");
+});


### PR DESCRIPTION
Adding forceDateValue property to component in order to support setting the value as JS Date instead of ISOString. 

This makes the component easier to use with DS.attr('date') properties, as no controller-mapping is required. 

Usage: 

    {{bootstrap-datepicker value=model.myDate format="dd.mm.yy" name="dateInput" language="no" forceDateValue=true}}