### PR TITLE
update bootstrap-datepicker on language change

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -82,6 +82,12 @@ export default Ember.Mixin.create({
            .apply(element, Array.prototype.concat.call(['update'], dates));
   },
 
+  _updateLanguage: Ember.observer('language', function() {
+    console.log('test');
+    this.$().datepicker('remove');
+    this.setupBootstrapDatepicker();
+  }),
+
   // HACK: Have to reset time to 00:00:00 because of the bug in
   //       bootstrap-datepicker
   //       Issue: http://git.io/qH7Hlg

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -58,6 +58,11 @@ export default Ember.Mixin.create({
     this.set('value', value);
   },
 
+  _didChangeLanguage: Ember.observer('language', function() {
+    this.$().datepicker('remove');
+    this.setupBootstrapDatepicker();
+  }),
+
   _updateDatepicker: function() {
     var self = this,
         element = this.$(),
@@ -81,12 +86,6 @@ export default Ember.Mixin.create({
     element.datepicker
            .apply(element, Array.prototype.concat.call(['update'], dates));
   },
-
-  _updateLanguage: Ember.observer('language', function() {
-    console.log('test');
-    this.$().datepicker('remove');
-    this.setupBootstrapDatepicker();
-  }),
 
   // HACK: Have to reset time to 00:00:00 because of the bug in
   //       bootstrap-datepicker


### PR DESCRIPTION
bootstrap-datepicker should be updated if language changes.
`bootstrap-datepicker` hasn't a native method yet to update language as discussed here: https://github.com/eternicode/bootstrap-datepicker/issues/362
Update bootstrap-datepicker and afterwards regenerate DOW row manual doesn't seem to work anymore. So only possible way seems to regenerate datepicker.