### PR TITLE
Send action changeDate.

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -56,6 +56,7 @@ export default Ember.Mixin.create({
     }
 
     this.set('value', value);
+    this.sendAction('changeDate', value);
   },
 
   _didChangeLanguage: Ember.observer('language', function() {


### PR DESCRIPTION
Currently if we want to do something every time the date changes we
need to use observers, with this approach we can avoid the use of
observers encouraging the use of Actions Up, Data Down.