### PR TITLE
Ember CLI install addon syntax change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ It doesn't have any external dependecy except bootstrap-datepicker.
 
 ## Installation
 
-If you are using Ember CLI 0.1.5 and higher, just run within your project directory:
+If you are using Ember CLI 0.2.3 or higher, just run within your project directory:
+
+```bash
+ember install:addon ember-cli-bootstrap-datepicker
+```
+
+If your Ember CLI version is greater than 0.1.5 and less than 0.2.3, run the following within your project directory:
 
 ```bash
 ember install:addon ember-cli-bootstrap-datepicker


### PR DESCRIPTION
Updated instructions to reflect change in Ember CLI addon installation. See https://github.com/ember-cli/ember-cli/pull/3598 for details.