### PR TITLE
Reset date value when input field is cleared.

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -39,6 +39,11 @@ export default Ember.Mixin.create({
         Ember.run(function() {
           self._didChangeDate(event);
         });
+      }).
+      on('input', function() {
+        if (!self.$().val()) {
+          self.set('value', null);
+        }
       });
 
     this._updateDatepicker();

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -30,6 +30,21 @@ test('should display date with default format when no format is set', function(a
   assert.equal(this.$().val(), '12/31/2014');
 });
 
+test('should reset date when input is cleared', function(assert) {
+  assert.expect(2);
+
+  this.subject({
+    value: new Date(2014, 11, 31)
+  });
+
+  assert.ok(this.$().datepicker('getDate'), 'initial value is set');
+
+  this.$().val('');
+  this.$().trigger('input');
+
+  assert.equal(this.$().datepicker('getDate'), null, 'value is reset when input is cleared');
+});
+
 test('should display date with custom format when format is set', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Listen to the input event and check if the input field is cleared. If yes, set the value to null.

I'm not sure if this is a good and feasible solution, but it fixes #33 for me.
Also I'm not very happy about the test since I have to trigger the input event manually to reset the date. But as far as I know there is currently no other way in Ember to test events on input fields (even the `fillIn` helper doesn't trigger any events)