### PR TITLE
Don't always update datepicker input

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
+  mustUpdateInput: true,
   value: null,
 
   setupBootstrapDatepicker: Ember.on('didInsertElement', function() {
@@ -63,6 +64,7 @@ export default Ember.Mixin.create({
       }
     }
 
+    this.set('mustUpdateInput', false); 
     this.set('value', value);
     this.sendAction('changeDate', value);
   },
@@ -77,6 +79,11 @@ export default Ember.Mixin.create({
         element = this.$(),
         value = this.get('value'),
         dates = [];
+
+    if (!this.get('mustUpdateInput')) {
+      this.set('mustUpdateInput', true);
+      return;
+    }
 
     switch (Ember.typeOf(value)) {
       case 'array':


### PR DESCRIPTION
Here is the problem I encountered.

The datepicker is a tool to help selecting date. But if the user wants to type dates by himself? You can't. Each time you type something, the input will be set to the current date. 

The cause is simple: each time value is updated, we call the method `update` on the datepicker. And as this method updates the input associated to the datepicker, after typing `1` in the input, calling `update` will automatically set the current date in the input. 

To my comprehension, the `_updateDatepicker` must be called each time `value` as been modified by anything but the component. For example: after a reset `this.set('myDate', null)` inside the controller. 

So here are my constraint: 
* The user type in the input? Don't call `_updateDatepicker`
* The controller containing the component modifies the value ? Call `_updateDatepicker`

I might have missed something, but the solution I came up with works fine. 
Hope you'll accept this :smile: 