### PR TITLE
Add support for live updating for start and end date

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -72,6 +72,16 @@ export default Ember.Mixin.create({
     this.setupBootstrapDatepicker();
   }),
 
+  _updateStartDate: Ember.observer('startDate', function() {
+    this.$().datepicker('setStartDate', this.get('startDate'));
+    this._updateDatepicker();
+  }),
+
+  _updateEndDate: Ember.observer('endDate', function() {
+    this.$().datepicker('setEndDate', this.get('endDate'));
+    this._updateDatepicker();
+  }),
+
   _updateDatepicker: function() {
     var self = this,
         element = this.$(),

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -65,3 +65,19 @@ test('should set dates provided by value (multidate, multidateSeparator provided
   assert.equal(this.$().val(), '01/13/2015;01/07/2015;01/15/2015', 'should set value as input field value using multidate separator');
   assert.equal(this.$().datepicker('getDates').length, 3, 'should set internal datepicker dates by value');
 });
+
+test('should update startDate', function(assert) {
+  assert.expect(2);
+  var startDate = new Date(2015, 2);
+  var newStartDate = new Date(2015, 3);
+
+  var component = this.subject({
+    value: new Date(2015, 4),
+    startDate: startDate
+  });
+
+  assert.equal(this.$().datepicker("setDate").o.startDate.getMonth(), startDate.getMonth(), 'should set initial startDate');
+
+  component.set("startDate", newStartDate);
+  assert.equal(this.$().datepicker("setDate").o.startDate.getMonth(), newStartDate.getMonth(), 'should update startDate');
+});


### PR DESCRIPTION
Currently, the component on instantiation will set the start and end date and you will no longer be able to update it. 

I have hooked the component into observing the values for `startDate` and `endDate` and used the native bootstrap-datepicker `set` methods to update it. I'm not sure about the internals of the jQuery implementation but I had to call `_updateDatepicker` to render the selection. There maybe a cleaner way to implement the rerender.