### PR TITLE
add observers *after* dom insertion

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -81,36 +81,38 @@ export default Ember.Mixin.create({
     this.sendAction('changeDate', value);
   },
 
-  _didChangeLanguage: Ember.observer('language', function() {
-    this.$().datepicker('remove');
-    this.setupBootstrapDatepicker();
-  }),
+  _addObservers: Ember.on('didInsertElement', function() {
+    this.addObserver('language', function() {
+      this.$().datepicker('remove');
+      this.setupBootstrapDatepicker();
+    });
 
-  _updateStartDate: Ember.observer('startDate', function() {
-    this.$().datepicker('setStartDate', this.get('startDate'));
-    this._updateDatepicker();
-  }),
+    this.addObserver('startDate', function() {
+      this.$().datepicker('setStartDate', this.get('startDate'));
+      this._updateDatepicker();
+    });
 
-  _updateEndDate: Ember.observer('endDate', function() {
-    this.$().datepicker('setEndDate', this.get('endDate'));
-    this._updateDatepicker();
-  }),
+    this.addObserver('endDate', function() {
+      this.$().datepicker('setEndDate', this.get('endDate'));
+      this._updateDatepicker();
+    });
 
-  _updateDatesDisabled: Ember.observer('datesDisabled', function() {
-    this.$().datepicker('setDatesDisabled', this.get('datesDisabled'));
-    this._updateDatepicker();
-  }),
+    this.addObserver('datesDisabled', function() {
+      this.$().datepicker('setDatesDisabled', this.get('datesDisabled'));
+      this._updateDatepicker();
+    });
 
-  _updateMinViewMode: Ember.observer('minViewMode', function() {
-    this.$().datepicker('minViewMode', this.get('minViewMode'));
-    this.$().data('datepicker')._process_options({minViewMode: this.get('minViewMode')});
-    this._updateDatepicker();
-  }),
+    this.addObserver('minViewMode', function() {
+      this.$().datepicker('minViewMode', this.get('minViewMode'));
+      this.$().data('datepicker')._process_options({minViewMode: this.get('minViewMode')});
+      this._updateDatepicker();
+    });
 
-  _updateFomat: Ember.observer('format', function() {
-    this.$().datepicker('format', this.get('format'));
-    this.$().data('datepicker')._process_options({format: this.get('format')});
-    this._updateDatepicker();
+    this.addObserver('format', function() {
+      this.$().datepicker('format', this.get('format'));
+      this.$().data('datepicker')._process_options({format: this.get('format')});
+      this._updateDatepicker();
+    });
   }),
 
   _updateDatepicker: function() {


### PR DESCRIPTION
if i do `{{bootstrap-datepicker value=expiresAt startDate='01/01/2001'}}` the component will throw an `cannot read property 'datepicker' of undefined` due to the respective observers [firing](https://github.com/soulim/ember-cli-bootstrap-datepicker/blob/master/addon/components/datepicker-support.js#L90) before `this.$()` has a value.

This PR is fixing that bug by adding those observers inside a `didInsertElement` hook.