### PR TITLE
Add support for iso date string values

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -133,6 +133,15 @@ export default Ember.Mixin.create({
       case 'date':
         dates = [value];
         break;
+      case 'string':
+        // try to convert strings to dates
+        // if it's an ISO formatted date it'll work, otherwise set to null
+        try {
+          dates = [new Date(value)];
+        } catch (e) {
+          dates = [null];
+        }
+        break;
       default:
         dates = [null];
     }

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -42,6 +42,14 @@ test('displays date with custom format when format is set', function(assert) {
   assert.equal(this.$().val(), '31.Dec.14');
 });
 
+test('allow input of ISO date strings', function(assert) {
+  this.subject({
+    value: '2014-12-31T06:00:00Z'
+  });
+
+  assert.equal(this.$().val(), '12/31/2014');
+});
+
 test('resets date when input is cleared', function(assert) {
   this.subject({
     value: new Date(2014, 11, 31)


### PR DESCRIPTION
Allow incoming date values to be ISO formatted dates that can be parsed automagically by JS.