### PR TITLE
Allow costum value parsing

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -9,6 +9,9 @@ export default Ember.Mixin.create({
   language: undefined,
   startDate: undefined,
   endDate: undefined,
+  customParser: function(value) {
+    return value;
+  },
 
   setupBootstrapDatepicker: Ember.on('didInsertElement', function() {
 
@@ -134,12 +137,15 @@ export default Ember.Mixin.create({
   _updateDatepicker: function() {
     var element = this.$(),
         value = this.get('value'),
+        customParser = this.get('customParser'),
         dates = [];
 
     if (!this.get('mustUpdateInput')) {
       this.set('mustUpdateInput', true);
       return;
     }
+
+    value = customParser(value);
 
     switch (Ember.typeOf(value)) {
       case 'array':

--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -42,6 +42,32 @@ test('displays date with custom format when format is set', function(assert) {
   assert.equal(this.$().val(), '31.Dec.14');
 });
 
+test('resets date when input is cleared', function(assert) {
+  this.subject({
+    value: new Date(2014, 11, 31)
+  });
+
+  assert.ok(this.$().datepicker('getDate'), 'initial value is set');
+
+  this.$().val('');
+  this.$().trigger('input');
+
+  assert.equal(this.$().datepicker('getDate'), null, 'value is reset when input is cleared');
+});
+
+test('should use customParser if provided', function(assert) {
+  assert.expect(1);
+
+  this.subject({
+    value: '2015-09-14T16:59:01+02:00',
+    customParser: function(value) {
+      return new Date(value);
+    }
+  });
+
+  assert.equal(this.$().val(), '09/14/2015');
+});
+
 test('sets dates provided by value (multidate, default multidateSeparator)', function(assert) {
   this.subject({
     value: [new Date(2015, 0, 13), new Date(2015, 0, 7), new Date(2015, 0, 15)],


### PR DESCRIPTION
This PR is related to #58. we too need the input value for our datepicker to sometimes be something else then a date. But I understand that using the `Date` constructor internally is unreliable. With this PR I simply introduce an API for the user to plug in a custom parser for the date string. This way anyone can decide by him/herself how to process the dates for a particular picker.

to solve @maladon's issue, he now could do:
```
{{bootstrap-datepicker value=expiresAt customParser=(action myParser)}}
```

and inside his code:

```js
actions: {
  myParser(value) {
    return new Date(value);
  }
}
```

The responsibility for how to parse is now in user land. If you want to, you could do fancy stuff with `moment.js` or other libraries not available from inside `bootstrap-datepicker`