### PR TITLE
Fix unwanted behavior when modifying time on the Date value

### DIFF
--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -137,7 +137,7 @@ export default Ember.Mixin.create({
         dates = [null];
     }
     dates = dates.map(function(date) {
-      return (Ember.isNone(date)) ? null : self._resetTime(date);
+      return (Ember.isNone(date)) ? null : self._getDateCloneWithNoTime(date);
     });
 
     element.datepicker
@@ -147,12 +147,14 @@ export default Ember.Mixin.create({
   // HACK: Have to reset time to 00:00:00 because of the bug in
   //       bootstrap-datepicker
   //       Issue: http://git.io/qH7Hlg
-  _resetTime: function(date) {
-    date.setHours(0);
-    date.setMinutes(0);
-    date.setSeconds(0);
-    date.setMilliseconds(0);
+  _getDateCloneWithNoTime: function(date) {
+    var clone = new Date(date.getTime());
 
-    return date;
+    clone.setHours(0);
+    clone.setMinutes(0);
+    clone.setSeconds(0);
+    clone.setMilliseconds(0);
+
+    return clone;
   }
 });


### PR DESCRIPTION
Since time was reset to 0 because of a bug on boostrap-datepicker, you
were not able to bind the component value on a Date object were you
would change its time value.

This fixes it with cloning the date object sent to the bootstrap
datepicker object.