### PR TITLE
Support clearDate, hide and show events

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,28 @@ The changeDate action is triggered when the selected date changes. It can be spe
 The action can be handled by a parent component, controller or route:
 
 ```javascript
-actions {
+actions: {
   changeDateAction(date) {
     // do sth with the new date
+  }
+}
+```
+
+#### clearDate
+
+The clearDate action is triggered when the date is cleared (e.g. when the "clear" button is clicked).
+
+
+```handlebars
+{{bootstrap-datepicker clearDate="clearDateAction"}}
+```
+
+The action can be handled by a parent component, controller or route:
+
+```javascript
+actions: {
+  clearDateAction() {
+    // do sth
   }
 }
 ```
@@ -235,7 +254,7 @@ The focus-in and focus-out actions are triggered when the respective focus event
 The actions can be handled by a parent component, controller or route:
 
 ```javascript
-actions {
+actions: {
   focusInAction(component, event) {
     // handle event
   },
@@ -245,6 +264,26 @@ actions {
 }
 ```
 
+#### hide & show
+
+The hide and show actions are triggered when the datepicker is either hidden or displayed.
+
+```handlebars
+{{bootstrap-datepicker hide="hideAction" show="showAction"}}
+```
+
+The actions can be handled by a parent component, controller or route:
+
+```javascript
+actions: {
+  hideAction() {
+    // datepicker is hidden
+  },
+  showAction() {
+    // datepicker is shown
+  }
+}
+```
 
 
 ## Contributing

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -58,6 +58,9 @@ export default Ember.Mixin.create({
         Ember.run(function() {
           self._didChangeDate(event);
         });
+      }).
+      on('show', function() {
+        self.sendAction('show');
       });
 
     this._updateDatepicker();

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -61,6 +61,9 @@ export default Ember.Mixin.create({
       }).
       on('show', function() {
         self.sendAction('show');
+      }).
+      on('hide', function() {
+        self.sendAction('hide');
       });
 
     this._updateDatepicker();

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -48,11 +48,6 @@ export default Ember.Mixin.create({
           self._didChangeDate(event);
         });
       }).
-      on('input', function() {
-        if (!self.$().val()) {
-          self._applyDateValue(null);
-        }
-      }).
       on('focusout', function(event) {
         self.sendAction('focus-out', self, event);
       }).
@@ -83,10 +78,6 @@ export default Ember.Mixin.create({
     }
 
     this.set('mustUpdateInput', false);
-    this._applyDateValue(value);
-  },
-
-  _applyDateValue: function(value) {
     this.set('value', value);
     this.sendAction('changeDate', value);
   },

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -53,6 +53,11 @@ export default Ember.Mixin.create({
       }).
       on('focusin', function(event) {
         self.sendAction('focus-in', self, event);
+      }).
+      on('clearDate', function(event) {
+        Ember.run(function() {
+          self._didChangeDate(event);
+        });
       });
 
     this._updateDatepicker();
@@ -79,7 +84,11 @@ export default Ember.Mixin.create({
 
     this.set('mustUpdateInput', false);
     this.set('value', value);
-    this.sendAction('changeDate', value);
+    if (event.type === 'clearDate') {
+      this.sendAction('clearDate');
+    } else {
+      this.sendAction('changeDate', value);
+    }
   },
 
   _addObservers: Ember.on('didInsertElement', function() {

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -11,7 +11,6 @@ export default Ember.Mixin.create({
   endDate: undefined,
 
   setupBootstrapDatepicker: Ember.on('didInsertElement', function() {
-    var self = this;
 
     this.$().
       datepicker({
@@ -43,27 +42,27 @@ export default Ember.Mixin.create({
         weekStart: this.get('weekStart'),
         datesDisabled: this.get('datesDisabled')
       }).
-      on('changeDate', function(event) {
-        Ember.run(function() {
-          self._didChangeDate(event);
+      on('changeDate', event => {
+        Ember.run(() => {
+          this._didChangeDate(event);
         });
       }).
-      on('focusout', function(event) {
-        self.sendAction('focus-out', self, event);
+      on('focusout', event => {
+        this.sendAction('focus-out', this, event);
       }).
-      on('focusin', function(event) {
-        self.sendAction('focus-in', self, event);
+      on('focusin', event => {
+        this.sendAction('focus-in', this, event);
       }).
-      on('clearDate', function(event) {
-        Ember.run(function() {
-          self._didChangeDate(event);
+      on('clearDate', event => {
+        Ember.run(() => {
+          this._didChangeDate(event);
         });
       }).
-      on('show', function() {
-        self.sendAction('show');
+      on('show', () => {
+        this.sendAction('show');
       }).
-      on('hide', function() {
-        self.sendAction('hide');
+      on('hide', () => {
+        this.sendAction('hide');
       });
 
     this._updateDatepicker();
@@ -133,8 +132,7 @@ export default Ember.Mixin.create({
   }),
 
   _updateDatepicker: function() {
-    var self = this,
-        element = this.$(),
+    var element = this.$(),
         value = this.get('value'),
         dates = [];
 
@@ -153,8 +151,8 @@ export default Ember.Mixin.create({
       default:
         dates = [null];
     }
-    dates = dates.map(function(date) {
-      return (Ember.isNone(date)) ? null : self._getDateCloneWithNoTime(date);
+    dates = dates.map(date => {
+      return (Ember.isNone(date)) ? null : this._getDateCloneWithNoTime(date);
     });
 
     element.datepicker

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -1,53 +1,8 @@
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('bootstrap-datepicker', 'BootstrapDatepickerComponent', {
   integration: true
-});
-
-test('resets date when input is cleared', function (assert) {
-  assert.expect(2);
-
-  this.set('myDate', new Date());
-
-  this.render(hbs`
-    {{bootstrap-datepicker value=myDate}}
-  `);
-  
-  var datepicker = this.$('input.ember-text-field').datepicker();  
- 
-  datepicker.val('');
-  Ember.run(() => {
-    datepicker.trigger('input');
-  });
-
-  assert.equal(this.get('myDate'), null, 'value is reset');
-  assert.equal(this.$('input.ember-text-field').datepicker('getDate'), null, 'datepicker is updated');
-});
-
-test('triggers changeDate action when input field is cleared', function (assert) {
-  assert.expect(1);
-
-  this.set('myDate', new Date());
-
-  var actionIsTriggered = false;
-  this.on('myAction', () => {
-    actionIsTriggered = true;
-  });
-
-  this.render(hbs`
-    {{bootstrap-datepicker value=myDate changeDate="myAction"}}
-  `);
-
-  var datepicker = this.$('input.ember-text-field').datepicker();  
-  
-  datepicker.val('');
-  Ember.run(() => {
-    datepicker.trigger('input');
-  });
-
-  assert.ok(actionIsTriggered, 'action is triggered');
 });
 
 test('triggers specified action on focusout event', function (assert) {

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -22,7 +22,6 @@ test('triggers specified action on focusout event', function (assert) {
   assert.ok(actionIsTriggered, 'action is triggered on focusout');
 });
 
-
 test('triggers specified action on focusin event', function (assert) {
   assert.expect(1);
 
@@ -80,3 +79,19 @@ test('triggers clearDate action when date selection is cleared', function(assert
   assert.ok(actionIsTriggered, 'action is triggered');
 });
 
+test('triggers show action when date datepicker is displayed', function(assert) {
+  assert.expect(1);
+
+  var actionIsTriggered = false;
+  this.on('myAction', () => {
+    actionIsTriggered = true;
+  });
+
+  this.render(hbs`
+    {{bootstrap-datepicker show="myAction"}}
+  `);
+
+  this.$('input.ember-text-field').trigger('show');
+
+  assert.ok(actionIsTriggered, 'action is triggered');
+});

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -95,3 +95,20 @@ test('triggers show action when date datepicker is displayed', function(assert) 
 
   assert.ok(actionIsTriggered, 'action is triggered');
 });
+
+test('triggers hide action when date datepicker is hidden', function(assert) {
+  assert.expect(1);
+
+  var actionIsTriggered = false;
+  this.on('myAction', () => {
+    actionIsTriggered = true;
+  });
+
+  this.render(hbs`
+    {{bootstrap-datepicker hide="myAction"}}
+  `);
+
+  this.$('input.ember-text-field').trigger('hide');
+
+  assert.ok(actionIsTriggered, 'action is triggered');
+});

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -39,3 +39,44 @@ test('triggers specified action on focusin event', function (assert) {
 
   assert.ok(actionIsTriggered, 'action is triggered on focusin');
 });
+
+test('triggers changeDate action when date selection changes', function(assert) {
+  assert.expect(1);
+
+  this.set('myDate', null);
+
+  var actionIsTriggered = false;
+  this.on('myAction', () => {
+    actionIsTriggered = true;
+  });
+
+  this.render(hbs`
+    {{bootstrap-datepicker value=myDate changeDate="myAction"}}
+  `);
+
+  var input = this.$('input.ember-text-field');
+  input.datepicker('setDate', new Date());
+
+  assert.ok(actionIsTriggered, 'action is triggered');
+});
+
+test('triggers clearDate action when date selection is cleared', function(assert) {
+  assert.expect(1);
+
+  this.set('myDate', new Date());
+
+  var actionIsTriggered = false;
+  this.on('myAction', () => {
+    actionIsTriggered = true;
+  });
+
+  this.render(hbs`
+    {{bootstrap-datepicker value=myDate clearDate="myAction"}}
+  `);
+
+  var input = this.$('input.ember-text-field');
+  input.datepicker('setDate', null);
+
+  assert.ok(actionIsTriggered, 'action is triggered');
+});
+


### PR DESCRIPTION
The first two commits could be squashed together probably. I left them separate to make it easier to follow the changes I made.

The last commit has nothing to do with the now supported events actually. It is just a small code cleanup/improvement.