### PR TITLE
pin jquery version to 1.11.3. fixes unit tests hanging.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
   },


### PR DESCRIPTION
My last pull request failed on Travis because the tests hang. Pinning the jQuery version fixed that on my machine.

See https://github.com/ember-cli/ember-cli/issues/5317