### PR TITLE
Fastboot check for loading bower components

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
-    app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+    if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
+      app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
+      app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+    }
   }
 };
+


### PR DESCRIPTION
Checking for Fastboot environment as when ember runs in fastboot, it doesn't have jQuery
