### PR TITLE
update jquery to 1.13.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-bootstrap-datepicker",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "1.13.13",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.8",


### PR DESCRIPTION
fixes testing issues
http://emberjs.com/blog/2016/01/15/ember-2-3-released.html#toc_removing-the-jquery-version-assertion

I think that's more straight forward than #77.