### PR TITLE
Fixes broken test introduced by #61

### DIFF
--- a/tests/unit/components/bootstrap-datepicker-test.js
+++ b/tests/unit/components/bootstrap-datepicker-test.js
@@ -50,7 +50,7 @@ test('resets date when input is cleared', function(assert) {
   assert.ok(this.$().datepicker('getDate'), 'initial value is set');
 
   this.$().val('');
-  this.$().trigger('input');
+  this.$().datepicker('update');
 
   assert.equal(this.$().datepicker('getDate'), null, 'value is reset when input is cleared');
 });


### PR DESCRIPTION
Test was broken since it was introduced by #61. Have to call `.datepicker('update')` to notify about changes.

I'm still not convinced about this test. It seems like testing bootstrap-datepicker and not this addon. But lets get a working testing suite again first.