### PR TITLE
travis should fail on latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 


### PR DESCRIPTION
Support for ember 2.x is critical. Therefore travis should fail for latest release.

Please merge #83 before which fixes tests against release and beta.