### PR TITLE
Import bootstrap-datepicker via npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,21 @@ submissions). If a full code (eg “de-DE”) is supplied the picker will first 
 if not found will fallback and check for a “de” language. If an unknown language code is given, English will 
 be used.
 
-When you need another language, you should import a locale file using your Brocfile.js. Just import `bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.<LANGUAGE_CODE>.js`, e.g.:
+When you need another language, just specify the
+`bootstrapDatepicker.includeLocales` config in `config/environment.js`:
 
 ```javascript
-// Brocfile.js
-app.import('bower_components/bootstrap-datepicker/js/locales/bootstrap-datepicker.de.js');
+// config/environment.js
+module.exports = function(environment) {
+  var ENV = {
+    // ...
+    bootstrapDatepicker: {
+      includeLocales: [ 'de' ]
+    }
+  };
+
+  return ENV;
+}
 ```
 
 Type: `String`

--- a/blueprints/bootstrap-datepicker/index.js
+++ b/blueprints/bootstrap-datepicker/index.js
@@ -1,7 +1,3 @@
 module.exports = {
   normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('bootstrap-datepicker');
-  }
 };

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "qunit": "~1.20.0"
   },
   "devDependencies": {
-    "bootstrap-datepicker": "~1.6.4",
     "bootstrap": "~3.3.7"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,7 +11,5 @@ module.exports = function(defaults) {
     destDir: 'assets'
   });
 
-  app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/locales/bootstrap-datepicker.de.min.js');
-
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -1,16 +1,112 @@
 /* jshint node: true */
 'use strict';
 
+var fs = require('fs');
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-cli-bootstrap-datepicker',
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
-      app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
-      app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+      // see: https://github.com/ember-cli/ember-cli/issues/3718
+      while (typeof app.import !== 'function' && app.app) {
+        app = app.app;
+      }
+
+      this.app = app;
+      this.bootstrapDatepickerOptions = this.getConfig();
+
+      var vendor = this.treePaths.vendor;
+
+      app.import({
+        development: vendor + '/bootstrap-datepicker/js/bootstrap-datepicker.js',
+        production: vendor + '/bootstrap-datepicker/js/bootstrap-datepicker.min.js'
+      });
+
+      app.import({
+        development: vendor + '/bootstrap-datepicker/css/bootstrap-datepicker.css',
+        production: vendor +  '/bootstrap-datepicker/css/bootstrap-datepicker.min.css'
+      }, { prepend: true });
+
+      if (this.bootstrapDatepickerOptions.includeLocales.length) {
+        this.bootstrapDatepickerOptions.includeLocales.forEach(function(locale) {
+          app.import(vendor +
+            '/bootstrap-datepicker/locales/bootstrap-datepicker.' + locale +
+            '.min.js'
+          );
+        });
+      }
     }
+  },
+
+  getConfig: function() {
+    var projectConfig = ((this.project.config(process.env.EMBER_ENV) || {}).bootstrapDatepicker || {});
+    var bootstrapDatepickerPath = path.join(
+      path.dirname(require.resolve('bootstrap-datepicker')),
+      '../'
+    );
+
+    var config = Object.assign({ includeLocales: [] }, projectConfig, {
+      path: bootstrapDatepickerPath
+    })
+
+    config.includeLocales = config.includeLocales
+      .filter(function(locale) {
+        return typeof locale === 'string';
+      })
+      .map(function(locale) {
+        return locale.replace('.js', '').trim().toLowerCase();
+      })
+      .filter(function(locale) {
+        if (locale === 'en') {
+          // english is the default language, skip
+          return false;
+        }
+
+        var localePath = bootstrapDatepickerPath +
+          '/locales/bootstrap-datepicker.' + locale + '.min.js';
+
+        if (!fs.existsSync(localePath)) {
+          console.error(
+            'ember-cli-bootstrap-datepicker: Specified locale "' + locale +
+            '" not found.'
+          );
+
+          return false;
+        }
+
+        return true;
+      });
+
+    return config;
+  },
+
+  treeForVendor: function(vendorTree) {
+    var trees = [];
+
+    if (vendorTree) {
+      trees.push(vendorTree);
+    }
+
+    var bootstrapDatepickerPath = this.bootstrapDatepickerOptions.path;
+
+    trees.push(new Funnel(bootstrapDatepickerPath, {
+      destDir: 'bootstrap-datepicker',
+      include: ['js/*.js', 'css/*.css']
+    }));
+
+    if (this.bootstrapDatepickerOptions.includeLocales.length) {
+      trees.push(new Funnel(bootstrapDatepickerPath, {
+        srcDir: 'locales',
+        destDir: 'bootstrap-datepicker/locales'
+      }));
+    }
+
+    return mergeTrees(trees);
   }
 };
-

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "datepicker"
   ],
   "dependencies": {
+    "bootstrap-datepicker": "^1.6.4",
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^5.1.5"
   },
   "main": "index.js",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,10 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    bootstrapDatepicker: {
+      includeLocales: [ 'de' ]
     }
   };
 

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -135,4 +136,16 @@ test('triggers changeMonth when month is changed', function(assert) {
   this.$('.prev:visible').trigger('click');
   assert.ok(lastDate instanceof Date, 'date is passed to action as argument');
   assert.equal(lastDate.getMonth(), new Date().getMonth(), 'passed date is correct');
+});
+
+test('works with localization', function(assert) {
+  assert.expect(1);
+
+  this.set('date', new Date('2017-03-21'));
+  this.render(hbs`
+    {{bootstrap-datepicker value=date language="de"}}
+  `);
+  this.$('input.ember-text-field').datepicker('show');
+
+  assert.equal($('.datepicker-switch').html(), 'März 2017');
 });


### PR DESCRIPTION
In our application, `ember-cli-bootstrap-datepicker` is the only dependency which uses bower. With this commit applications no longer depend on bower.

This PR is not backwards compatible for users who import their locales via `app.import(...)`.