### PR TITLE
Adding support for using this addon inside other addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,14 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
-    app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+    if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
+      if (typeof this.import === 'function' && !app.bowerDirectory) {
+        this.import('bower_components/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
+        this.import('bower_components/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+      } else {
+        app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/js/bootstrap-datepicker.js');
+        app.import(app.bowerDirectory + '/bootstrap-datepicker/dist/css/bootstrap-datepicker.css');
+      }
+    }
   }
 };


### PR DESCRIPTION
Current release doesn't allow to use this addon inside other addons as `app.bowerDirectory` is being hardcoded in `index.js`. We should switch to solution proposed by author of `ember-run-raf` initially. 